### PR TITLE
Fix typo and add missing jsdoc

### DIFF
--- a/src/languages/language.js
+++ b/src/languages/language.js
@@ -43,10 +43,11 @@ export default class BananaLanguage {
    * For the number, get the plural for index
    *
    * @param {integer} number
+   * @param {string} locale
    * @return {integer} plural form index
    */
   getPluralForm (number, locale) {
-    // Alowed forms as per CLDR spec
+    // Allowed forms as per CLDR spec
     const pluralForms = [ 'zero', 'one', 'two', 'few', 'many', 'other' ]
     // Create an instance of Intl PluralRules. If the locale is invalid or
     // not supported, it fallbacks to `en`.


### PR DESCRIPTION
(FYI: The type could also be "string | string[]" according to the type definition.)