### PR TITLE
Introduce option to enable wiki links processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Note that {{GENDER:...}} is not case sensitive. It can be {{gender:...}} too.
 ## Grammar
 
 ```javascript
-const banana=new Banana( { locale: 'fi' } );
+const banana=new Banana( 'fi' );
 
 const message = "{{grammar:genitive|$1}}";
 
@@ -205,6 +205,18 @@ To avoid BIDI corruption that looks like "(Foo_(Bar", which happens when a strin
 
 The embedded context's directionality is determined by looking at the argument for `$1`, and then explicitly inserted into the Unicode text, ensuring correct rendering (because then the bidi algorithm "knows" the argument text is a separate context).
 
+## Wiki style links
+
+The message can have [mediawiki markup style links](https://en.wikipedia.org/wiki/Help:Wikitext#Links_and_URLs). By default this is disabled. To enables support for this, pass `wikilinks=true` option to `Banana` constructor. Example:
+
+```
+new Banana('es', { wikilinks:true } )
+```
+
+The original wiki links markup is elaborate, but here we only support simple syntax.
+
+* Internal links:  `[[pageTitle]]`  or `[[pageTitle|displayText]]`
+* External links: `[externalURL]` or `[externalURL displayText]`
 
 ## Message documentation
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ new Banana('es', { wikilinks: true } )
 
 The original wiki links markup is elaborate, but here we only support simple syntax.
 
-* Internal links:  `[[pageTitle]]`  or `[[pageTitle|displayText]]`
+* Internal links:  `[[pageTitle]]`  or `[[pageTitle|displayText]]`. For example `[[Apple]]` gives `<a href="./Apple" title="Apple">Apple</a>`.
 * External links: `[https://example.com]` or `[https://example.com display text]`
 
 ## Message documentation

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Note that {{GENDER:...}} is not case sensitive. It can be {{gender:...}} too.
 ## Grammar
 
 ```javascript
-const banana=new Banana( 'fi' );
+const banana = new Banana( 'fi' );
 
 const message = "{{grammar:genitive|$1}}";
 
@@ -207,16 +207,16 @@ The embedded context's directionality is determined by looking at the argument f
 
 ## Wiki style links
 
-The message can have [mediawiki markup style links](https://en.wikipedia.org/wiki/Help:Wikitext#Links_and_URLs). By default this is disabled. To enables support for this, pass `wikilinks=true` option to `Banana` constructor. Example:
+The message can use [MediaWiki link syntax](https://www.mediawiki.org/wiki/Help:Links). By default this is disabled. To enable support for this, pass `wikilinks=true` option to `Banana` constructor. Example:
 
 ```
-new Banana('es', { wikilinks:true } )
+new Banana('es', { wikilinks: true } )
 ```
 
 The original wiki links markup is elaborate, but here we only support simple syntax.
 
 * Internal links:  `[[pageTitle]]`  or `[[pageTitle|displayText]]`
-* External links: `[externalURL]` or `[externalURL displayText]`
+* External links: `[https://example.com]` or `[https://example.com display text]`
 
 ## Message documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "banana-i18n",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "banana-i18n",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "banana-i18n",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Banana Internationalization library",
   "main": "dist/banana-i18n.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "banana-i18n",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "Banana Internationalization library",
   "main": "dist/banana-i18n.js",
   "scripts": {

--- a/src/ast.js
+++ b/src/ast.js
@@ -15,7 +15,7 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   function choice (parserSyntax) {
     return () => {
       for (let i = 0; i < parserSyntax.length; i++) {
-        let result = parserSyntax[ i ]()
+        const result = parserSyntax[i]()
 
         if (result !== null) {
           return result
@@ -30,12 +30,12 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   // All must succeed; otherwise, return null.
   // This is the only eager one.
   function sequence (parserSyntax) {
-    let originalPos = pos
+    const originalPos = pos
 
-    let result = []
+    const result = []
 
     for (let i = 0; i < parserSyntax.length; i++) {
-      let res = parserSyntax[ i ]()
+      const res = parserSyntax[i]()
 
       if (res === null) {
         pos = originalPos
@@ -53,9 +53,9 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   // Must succeed a minimum of n times; otherwise, return null.
   function nOrMore (n, p) {
     return () => {
-      let originalPos = pos
+      const originalPos = pos
 
-      let result = []
+      const result = []
 
       let parsed = p()
 
@@ -77,7 +77,7 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   // Helpers -- just make parserSyntax out of simpler JS builtin types
 
   function makeStringParser (s) {
-    let len = s.length
+    const len = s.length
 
     return () => {
       let result = null
@@ -93,15 +93,15 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
 
   function makeRegexParser (regex) {
     return () => {
-      let matches = message.slice(pos).match(regex)
+      const matches = message.slice(pos).match(regex)
 
       if (matches === null) {
         return null
       }
 
-      pos += matches[ 0 ].length
+      pos += matches[0].length
 
-      return matches[ 0 ]
+      return matches[0]
     }
   }
 
@@ -113,7 +113,7 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   const dollar = makeStringParser('$')
   const digits = makeRegexParser(/^\d+/)
   // A literal is any character except the special characters in the message markup
-  // Special characters are: [,],{,},$.
+  // Special characters are: [, ], {, }, $, \
   // If wikilinks parsing is disabled, treat [ and ] as regular text.
   const regularLiteral = wikilinks ? makeRegexParser(/^[^{}[\]$\\]/) : makeRegexParser(/^[^{}$\\]/)
   const regularLiteralWithoutBar = wikilinks ? makeRegexParser(/^[^{}[\]$\\|]/) : makeRegexParser(/^[^{}$\\|]/)
@@ -128,7 +128,7 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   // May be some scoping issue.
   function transform (p, fn) {
     return () => {
-      let result = p()
+      const result = p()
       return result === null ? null : fn(result)
     }
   }
@@ -137,7 +137,7 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   // character is the parameter delimeter, so by default
   // it is not a literal in the parameter
   function literalWithoutBar () {
-    let result = nOrMore(1, escapedOrLiteralWithoutBar)()
+    const result = nOrMore(1, escapedOrLiteralWithoutBar)()
 
     return result === null ? null : result.join('')
   }
@@ -162,23 +162,23 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   }
 
   function escapedLiteral () {
-    let result = sequence([ backslash, anyCharacter ])
+    const result = sequence([backslash, anyCharacter])
 
-    return result === null ? null : result[ 1 ]
+    return result === null ? null : result[1]
   }
 
-  choice([ escapedLiteral, regularLiteralWithoutSpace ])
-  escapedOrLiteralWithoutBar = choice([ escapedLiteral, regularLiteralWithoutBar ])
-  escapedOrRegularLiteral = choice([ escapedLiteral, regularLiteral ])
+  choice([escapedLiteral, regularLiteralWithoutSpace])
+  escapedOrLiteralWithoutBar = choice([escapedLiteral, regularLiteralWithoutBar])
+  escapedOrRegularLiteral = choice([escapedLiteral, regularLiteral])
 
   function replacement () {
-    let result = sequence([ dollar, digits ])
+    const result = sequence([dollar, digits])
 
     if (result === null) {
       return null
     }
 
-    return [ 'REPLACE', parseInt(result[ 1 ], 10) - 1 ]
+    return ['REPLACE', parseInt(result[1], 10) - 1]
   }
 
   templateName = transform(
@@ -192,52 +192,52 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
   )
 
   function templateParam () {
-    let result = sequence([ pipe, nOrMore(0, paramExpression) ])
+    const result = sequence([pipe, nOrMore(0, paramExpression)])
 
     if (result === null) {
       return null
     }
 
-    let expr = result[ 1 ]
+    const expr = result[1]
 
     // use a "CONCAT" operator if there are multiple nodes,
     // otherwise return the first node, raw.
-    return expr.length > 1 ? [ 'CONCAT' ].concat(expr) : expr[ 0 ]
+    return expr.length > 1 ? ['CONCAT'].concat(expr) : expr[0]
   }
 
   function templateWithReplacement () {
-    let result = sequence([ templateName, colon, replacement ])
+    const result = sequence([templateName, colon, replacement])
 
-    return result === null ? null : [ result[ 0 ], result[ 2 ] ]
+    return result === null ? null : [result[0], result[2]]
   }
 
   function templateWithOutReplacement () {
-    let result = sequence([ templateName, colon, paramExpression ])
+    const result = sequence([templateName, colon, paramExpression])
 
-    return result === null ? null : [ result[ 0 ], result[ 2 ] ]
+    return result === null ? null : [result[0], result[2]]
   }
 
   templateContents = choice([
     function () {
-      let res = sequence([
+      const res = sequence([
         // templates can have placeholders for dynamic
         // replacement eg: {{PLURAL:$1|one car|$1 cars}}
         // or no placeholders eg:
         // {{GRAMMAR:genitive|{{SITENAME}}}
-        choice([ templateWithReplacement, templateWithOutReplacement ]),
+        choice([templateWithReplacement, templateWithOutReplacement]),
         nOrMore(0, templateParam)
       ])
 
-      return res === null ? null : res[ 0 ].concat(res[ 1 ])
+      return res === null ? null : res[0].concat(res[1])
     },
     function () {
-      let res = sequence([ templateName, nOrMore(0, templateParam) ])
+      const res = sequence([templateName, nOrMore(0, templateParam)])
 
       if (res === null) {
         return null
       }
 
-      return [ res[ 0 ] ].concat(res[ 1 ])
+      return [res[0]].concat(res[1])
     }
   ])
 
@@ -252,9 +252,9 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
    * An expression in the form of {{...}}
    */
   function template () {
-    let result = sequence([ openTemplate, templateContents, closeTemplate ])
+    const result = sequence([openTemplate, templateContents, closeTemplate])
 
-    return result === null ? null : result[ 1 ]
+    return result === null ? null : result[1]
   }
 
   function pipedWikilink () {
@@ -264,8 +264,8 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
       nOrMore(1, expression)
     ])
     return result === null ? null : [
-      [ 'CONCAT' ].concat(result[ 0 ]),
-      [ 'CONCAT' ].concat(result[ 2 ])
+      ['CONCAT'].concat(result[0]),
+      ['CONCAT'].concat(result[2])
     ]
   }
 
@@ -274,7 +274,7 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
       nOrMore(1, paramExpression)
     ])
     return result === null ? null : [
-      [ 'CONCAT' ].concat(result[ 0 ])
+      ['CONCAT'].concat(result[0])
     ]
   }
 
@@ -293,8 +293,8 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
     ])
 
     if (parsedResult !== null) {
-      const parsedLinkContents = parsedResult[ 1 ]
-      result = [ 'WIKILINK' ].concat(parsedLinkContents)
+      const parsedLinkContents = parsedResult[1]
+      result = ['WIKILINK'].concat(parsedLinkContents)
     }
 
     return result
@@ -317,13 +317,13 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
       // passing fancy parameters (like a whole jQuery object or a function) to use for the
       // link. Check only if it's a single match, since we can either do CONCAT or not for
       // singles with the same effect.
-      const target = parsedResult[ 1 ].length === 1
-        ? parsedResult[ 1 ][ 0 ]
-        : [ 'CONCAT' ].concat(parsedResult[ 1 ])
+      const target = parsedResult[1].length === 1
+        ? parsedResult[1][0]
+        : ['CONCAT'].concat(parsedResult[1])
       result = [
         'EXTLINK',
         target,
-        [ 'CONCAT' ].concat(parsedResult[ 3 ])
+        ['CONCAT'].concat(parsedResult[3])
       ]
     }
 
@@ -346,16 +346,16 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
     literal
   ])
 
-  paramExpression = choice([ template, replacement, literalWithoutBar ])
+  paramExpression = choice([template, replacement, literalWithoutBar])
 
   function start () {
-    let result = nOrMore(0, expression)()
+    const result = nOrMore(0, expression)()
 
     if (result === null) {
       return null
     }
 
-    return [ 'CONCAT' ].concat(result)
+    return ['CONCAT'].concat(result)
   }
 
   result = start()

--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,23 @@ import BananaMessageStore from './messagestore'
 import fallbacks from './languages/fallbacks.json'
 
 export default class Banana {
-  constructor (locale, options) {
-    options = options || {}
+  /**
+   * @param {string} locale
+   * @param {Object} options options
+   * @param {string} [options.finalFallback] Final fallback locale
+   * @param {Object|undefined} [options.messages] messages
+   * @param {boolean} [options.wikilinks] whether the wiki style link syntax should be parsed or not
+   */
+  constructor (locale, {
+    finalFallback = 'en', messages = undefined, wikilinks = false } = {}
+  ) {
     this.locale = locale
-    this.parser = new BananaParser(this.locale)
+    this.parser = new BananaParser(this.locale, { wikilinks })
     this.messageStore = new BananaMessageStore()
-    if (options.messages) {
-      this.load(options.messages, this.locale)
+    if (messages) {
+      this.load(messages, this.locale)
     }
-    this.finalFallback = options.finalFallback || 'en'
+    this.finalFallback = finalFallback
   }
 
   /**

--- a/src/parser.js
+++ b/src/parser.js
@@ -2,14 +2,21 @@ import BananaEmitter from './emitter'
 import BananaMessage from './ast'
 
 export default class BananaParser {
-  constructor (locale) {
+  /**
+   *
+   * @param {string} locale
+   * @param {Object} options options
+   * @param {boolean} [options.wikilinks] whether the wiki style link syntax should be parsed or not
+   */
+  constructor (locale, { wikilinks = false } = {}) {
     this.locale = locale
+    this.wikilinks = wikilinks
     this.emitter = new BananaEmitter(this.locale)
   }
 
   parse (message, params) {
-    if (message.includes('{{') || message.includes('[')) {
-      let ast = new BananaMessage(message)
+    if (message.includes('{{') || (this.wikilinks && message.includes('['))) {
+      const ast = BananaMessage(message, { wikilinks: this.wikilinks })
       return this.emitter.emit(ast, params)
     } else {
       return this.simpleParse(message, params)

--- a/test/banana.test.js
+++ b/test/banana.test.js
@@ -598,7 +598,7 @@ describe('Banana', function () {
   })
 
   it('should localize the messages with wiki liinks', () => {
-    const banana = new Banana('en')
+    const banana = new Banana('en', { wikilinks: true })
     banana.load({
       'msg-with-extlink': 'This is a link to [https://wikipedia.org wikipedia]',
       'msg-with-wikilink': 'This is a link to [[Apple|Apple Page]]',
@@ -618,6 +618,22 @@ describe('Banana', function () {
       banana.i18n('msg-with-wikilink-no-anchor'),
       'This is a link to <a href="./Apple" title="Apple">Apple</a>',
       'Internal Wiki style link with link and title being same'
+    )
+  })
+
+  it('should skip wiki links if disabled', () => {
+    const banana = new Banana('en', { wikilinks: false })
+    banana.load({
+      'msg-with-extlink': 'This is reference [10]',
+      'msg-with-wikilink': '$1 more {{plural:$1|item|items}} [[...]]'
+    }, 'en')
+    assert.strictEqual(
+      banana.i18n('msg-with-extlink'),
+      'This is reference [10]'
+    )
+    assert.strictEqual(
+      banana.i18n('msg-with-wikilink', 10),
+      '10 more items [[...]]'
     )
   })
 


### PR DESCRIPTION
Introduce option to enable wiki links processing

By default this option is disabled.

Includes tests and documentation update.

This is a breaking change. So the master version update too.

Fixes issue #37