### PR TITLE
Export BananaParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/banana-i18n.js",
   "scripts": {
     "test": "NODE_ENV=test mocha",
-    "build": "webpack --mode=production"
+    "build": "webpack --mode=production",
+    "prepare": "npm run build"
   },
   "keywords": [
     "internationalization",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import BananaParser from './parser'
 import BananaMessageStore from './messagestore'
 import fallbacks from './languages/fallbacks.json'
 
+export { BananaParser }
+
 export default class Banana {
   /**
    * @param {string} locale

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './src/index.js',
   output: {
     library: 'Banana',
-    libraryExport: 'default',
+    libraryExport: '',
     libraryTarget: 'umd',
     globalObject: 'this',
     filename: 'banana-i18n.js',


### PR DESCRIPTION
Export the BananaParser class so that it can be used directly by code
embedding this library.

Bug: T270787