### PR TITLE
Add support for formatnum operation

### DIFF
--- a/src/emitter.js
+++ b/src/emitter.js
@@ -230,6 +230,23 @@ class BananaEmitter {
     // No strong directionality: do not wrap
     return nodes[0]
   }
+
+  /**
+   * Takes an unformatted number (arab, no group separators and . as decimal separator)
+   * and outputs it in the localized digit script and formatted with decimal
+   * separator, according to the current language.
+   *
+   * @param {Array} nodes List of nodes
+   * @return {number|string} Formatted number
+   */
+  formatnum (nodes) {
+    let isInteger = !!nodes[1] && nodes[1] === 'R'
+    let number = nodes[0]
+    if (typeof number === 'string' || typeof number === 'number') {
+      return this.language.convertNumber(number, isInteger)
+    }
+    return number
+  }
 }
 
 /**

--- a/test/banana.test.js
+++ b/test/banana.test.js
@@ -503,6 +503,16 @@ describe('Banana', function () {
     )
   })
 
+  it('should parse formatnum', () => {
+    let locale = 'hi'
+    const banana = new Banana(locale)
+    assert.strictEqual(
+      banana.i18n('{{formatnum:34242}}'),
+      '३४२४२',
+      'Devanagiri numerals'
+    )
+  })
+
   it('should parse the Arabic message', () => {
     const locale = 'ar'
     const banana = new Banana(locale)


### PR DESCRIPTION
Provides the functionality of formatnum operation which is available in mw.JQueryMsg.

The digit transforms data is already available in the repo.

Code copied from https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/refs/heads/master/resources/src/mediawiki.jqueryMsg/mediawiki.jqueryMsg.js#1445