### PR TITLE
add function to allow users to register their own parser hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The original wiki links markup is elaborate, but here we only support simple syn
 
 ## Extending the parser
 
-Following example illustrates extending the parser to support more magic words
+Following example illustrates extending the parser to support more parser plugins
 
 ```js
 const banana = new Banana('en');
@@ -234,7 +234,7 @@ banana.registerParserPlugin('link', (nodes) => {
 
 This will parse the message
 ```js
-banana.i18n( '{{link:{{SITENAME}}|https://en.wikipedia.org}}' );
+banana.i18n('{{link:{{SITENAME}}|https://en.wikipedia.org}}');
 ```
 to
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,30 @@ The original wiki links markup is elaborate, but here we only support simple syn
 * Internal links:  `[[pageTitle]]`  or `[[pageTitle|displayText]]`. For example `[[Apple]]` gives `<a href="./Apple" title="Apple">Apple</a>`.
 * External links: `[https://example.com]` or `[https://example.com display text]`
 
+## Extending the parser
+
+Following example illustrates extending the parser to support more magic words
+
+```js
+const banana = new Banana('en');
+banana.registerParserPlugin('sitename', () => {
+  return 'Wikipedia';
+});
+banana.registerParserPlugin('link', (nodes) => {
+  return '<a href="' + nodes[1] + '">' + nodes[0] + '</a>';
+});
+```
+
+This will parse the message
+```js
+banana.i18n( '{{link:{{SITENAME}}|https://en.wikipedia.org}}' );
+```
+to
+
+```
+<a href="https://en.wikipedia.org">Wikipedia</a>
+```
+
 ## Message documentation
 
 The message keys and messages won't give a enough context about the message being translated to the translator. Whenever a developer adds a new message, it is a usual practice to document the message to a file named qqq.json

--- a/src/index.js
+++ b/src/index.js
@@ -79,17 +79,17 @@ export default class Banana {
    * Register a plugin for the library's message parser
    * Example:
    * <pre>
-   *   banana.registerParserPlugin('sysop', nodes => {
-   *     return mw.config.get('wgUserGroups').includes('sysop') ?
-   *       nodes[1] : nodes[2]
+   *   banana.registerParserPlugin('foobar', nodes => {
+   *     return nodes[0] === 'foo ? nodes[1] : nodes[2]
    *   }
    * </pre>
-   * This allows messages to know if the user is a sysop. Usage:
+   * Usage:
    * <pre>
-   *   banana.i18n('this is a message {{sysop:_|Message for sysops|Message for non-sysops}}')
+   *   banana.i18n('{{foobar:foo|first message|second message}}') --> 'first message'
+   *   banana.i18n('{{foobar:bar|first message|second message}}') --> 'second message'
    * </pre>
    * See emitter.js for built-in parser operations.
-   * @param {string} name - the name of the parser hook
+   * @param {string} name - the name of the plugin
    * @param {Function} plugin - the plugin function. It receives nodes as argument -
    * a mixed array corresponding to the pipe-separated objects in the operation.
    */

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import BananaParser from './parser'
 import BananaMessageStore from './messagestore'
 import fallbacks from './languages/fallbacks.json'
+import BananaEmitter from './emitter'
 
 export default class Banana {
   /**
@@ -72,5 +73,27 @@ export default class Banana {
       fallbackIndex++
     }
     return messageKey
+  }
+
+  /**
+   * Register a plugin for the library's message parser
+   * Example:
+   * <pre>
+   * 	banana.registerParserPlugin('sysop', nodes => {
+   * 	  return mw.config.get('wgUserGroups').includes('sysop') ?
+   * 	  	nodes[1] : nodes[2]
+   * 	}
+   * </pre>
+   * This allows messages to know if the user is a sysop. Usage:
+   * <pre>
+   * 	banana.i18n('this is a message {{sysop:|Message for sysops|Message for non-sysops}}')
+   * </pre>
+   * See emitter.js for built-in parser operations.
+   * @param {string} name - the name of the parser hook
+   * @param {Function} plugin - the plugin function. It receives nodes as argument -
+   * a mixed array corresponding to the pipe-separated objects in the operation.
+   */
+  registerParserPlugin(name, plugin) {
+  	BananaEmitter.prototype[name] = plugin;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ export default class Banana {
    * Example:
    * <pre>
    *   banana.registerParserPlugin('foobar', nodes => {
-   *     return nodes[0] === 'foo ? nodes[1] : nodes[2]
+   *     return nodes[0] === 'foo' ? nodes[1] : nodes[2]
    *   }
    * </pre>
    * Usage:

--- a/src/index.js
+++ b/src/index.js
@@ -79,21 +79,21 @@ export default class Banana {
    * Register a plugin for the library's message parser
    * Example:
    * <pre>
-   * 	banana.registerParserPlugin('sysop', nodes => {
-   * 	  return mw.config.get('wgUserGroups').includes('sysop') ?
-   * 	  	nodes[1] : nodes[2]
-   * 	}
+   *   banana.registerParserPlugin('sysop', nodes => {
+   *     return mw.config.get('wgUserGroups').includes('sysop') ?
+   *       nodes[1] : nodes[2]
+   *   }
    * </pre>
    * This allows messages to know if the user is a sysop. Usage:
    * <pre>
-   * 	banana.i18n('this is a message {{sysop:|Message for sysops|Message for non-sysops}}')
+   *   banana.i18n('this is a message {{sysop:|Message for sysops|Message for non-sysops}}')
    * </pre>
    * See emitter.js for built-in parser operations.
    * @param {string} name - the name of the parser hook
    * @param {Function} plugin - the plugin function. It receives nodes as argument -
    * a mixed array corresponding to the pipe-separated objects in the operation.
    */
-  registerParserPlugin(name, plugin) {
-  	BananaEmitter.prototype[name] = plugin;
+  registerParserPlugin (name, plugin) {
+    BananaEmitter.prototype[name] = plugin
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import BananaParser from './parser'
 import BananaMessageStore from './messagestore'
-import fallbacks from './languages/fallbacks.json'
 import BananaEmitter from './emitter'
+import fallbacks from './languages/fallbacks.json'
 
 export default class Banana {
   /**
@@ -86,7 +86,7 @@ export default class Banana {
    * </pre>
    * This allows messages to know if the user is a sysop. Usage:
    * <pre>
-   *   banana.i18n('this is a message {{sysop:|Message for sysops|Message for non-sysops}}')
+   *   banana.i18n('this is a message {{sysop:_|Message for sysops|Message for non-sysops}}')
    * </pre>
    * See emitter.js for built-in parser operations.
    * @param {string} name - the name of the parser hook

--- a/test/banana.test.js
+++ b/test/banana.test.js
@@ -513,6 +513,36 @@ describe('Banana', function () {
     )
   })
 
+  it('should allow custom parser plugins', () => {
+    let locale = 'en'
+    const banana = new Banana(locale)
+    banana.registerParserPlugin('foobar', (nodes) => {
+      return nodes[0] === 'foo' ? nodes[1] : nodes[2]
+    })
+    assert.strictEqual(
+      banana.i18n('{{foobar:foo|first|second}}'),
+      'first',
+      'Emits first argument on passing foo to foobar plugin hook'
+    )
+    assert.strictEqual(
+      banana.i18n('{{foobar:bar|first|second}}'),
+      'second',
+      'Emits second argument on passing bar to foobar plugin hook'
+    )
+
+    banana.registerParserPlugin('sitename', () => {
+      return 'Wikipedia';
+    });
+    banana.registerParserPlugin('link', (nodes) => {
+      return '<a href="' + nodes[1] + '">' + nodes[0] + '</a>';
+    });
+    assert.strictEqual(
+      banana.i18n( '{{link:{{SITENAME}}|https://en.wikipedia.org}}' ),
+      '<a href="https://en.wikipedia.org">Wikipedia</a>',
+      'complex use of custom parser plugins'
+    )
+  })
+
   it('should parse the Arabic message', () => {
     const locale = 'ar'
     const banana = new Banana(locale)

--- a/test/banana.test.js
+++ b/test/banana.test.js
@@ -531,13 +531,13 @@ describe('Banana', function () {
     )
 
     banana.registerParserPlugin('sitename', () => {
-      return 'Wikipedia';
-    });
+      return 'Wikipedia'
+    })
     banana.registerParserPlugin('link', (nodes) => {
-      return '<a href="' + nodes[1] + '">' + nodes[0] + '</a>';
-    });
+      return '<a href="' + nodes[1] + '">' + nodes[0] + '</a>'
+    })
     assert.strictEqual(
-      banana.i18n( '{{link:{{SITENAME}}|https://en.wikipedia.org}}' ),
+      banana.i18n('{{link:{{SITENAME}}|https://en.wikipedia.org}}'),
       '<a href="https://en.wikipedia.org">Wikipedia</a>',
       'complex use of custom parser plugins'
     )

--- a/types/banana-i18n.d.ts
+++ b/types/banana-i18n.d.ts
@@ -22,7 +22,7 @@ export interface Banana {
 	setLocale( locale: string ): void;
 	getFallbackLocales(): string[];
 	getMessage( messageKey: string ): string;
-	registerParserPlugin ( name: string, plugin: ((nodes: ParameterType[]) => string) ): void;
+	registerParserPlugin( name: string, plugin: ((nodes: ParameterType[]) => string) ): void;
 }
 
 export const Banana: BananaConstructor;

--- a/types/banana-i18n.d.ts
+++ b/types/banana-i18n.d.ts
@@ -1,5 +1,5 @@
 export interface Messages {
-	[ messageKey: string ]: string|Record<string, any>; 
+	[ messageKey: string ]: string|Record<string, any>;
 }
 
 export interface BananaOptions {
@@ -22,6 +22,7 @@ export interface Banana {
 	setLocale( locale: string ): void;
 	getFallbackLocales(): string[];
 	getMessage( messageKey: string ): string;
+	registerParserPlugin ( name: string, plugin: ((nodes: ParameterType[]) => string) ): void;
 }
 
 export const Banana: BananaConstructor;


### PR DESCRIPTION
A simple contrived example would be:

- banana.registerParserPlugin('foobar', nodes => nodes[0] === 'foo' ? nodes[1]: nodes[2])

Which makes
- banana.i18n('{{foobar:foo|first|second}}') --> 'first'
- banana.i18n('{{foobar:bar|first|second}}') --> 'second'

This can be used practically for a lot of purposes, particularly for operations that require some data to be available which can be fetched from the client script. For example on mediawiki sites, a client script could add a hook for formatting dates using the month names fetched from MediaWiki API.

Let me know what you think about this. Another less explicit way of allowing these hooks would be to export the BananaEmitter class, so that clients can directly modify its prototype.