### PR TITLE
Fix types

### DIFF
--- a/types/banana-i18n.d.ts
+++ b/types/banana-i18n.d.ts
@@ -3,8 +3,9 @@ export interface Messages {
 }
 
 export interface BananaOptions {
-	messages?: Messages;
+	messages?: Messages | MessageSource;
 	finalFallback?: string;
+	wikilinks?: boolean;
 }
 
 export interface BananaConstructor {
@@ -17,7 +18,7 @@ export type ParameterType = string|object|number|undefined;
 
 export interface Banana {
 	locale: string;
-	load( messsageSource: MessageSource, locale?: string ): void;
+	load( messageSource: Messages | MessageSource, locale?: string ): void;
 	i18n( key: string, ...params: ParameterType[] ): string;
 	setLocale( locale: string ): void;
 	getFallbackLocales(): string[];

--- a/types/tests/banana-test.ts
+++ b/types/tests/banana-test.ts
@@ -6,7 +6,7 @@ let banana1 = new Banana('zh', {
 	}
 } );
 
-const banana2 = new Banana('zh', { finalFallback: 'ru' } );
+const banana2 = new Banana('zh', { finalFallback: 'ru', wikilinks: true } );
 
 const messages = {
 	'es': {
@@ -22,6 +22,12 @@ const messages = {
 	}
 };
 
+const messages2 = {
+	'@metadata': { data: 'me' },
+	'message-key-1': 'Localized message 1 for zh',
+	'message-key-2': 'Localized message 2 for zh with $1',
+};
+
 banana1 = new Banana( 'ru' );
 banana1.load( messages );
 banana1.setLocale( 'an' );
@@ -29,6 +35,8 @@ banana1.i18n( 'message-key-1' ); // should return: Localized message 1 for es
 banana1.i18n( 'message-key-2', 'parameter' ); // should return: Localized message 2 for es with parameter
 // @see src/languages/fallback.json
 banana1.getFallbackLocales(); // should return: [ 'es' ]
+
+banana2.load( messages2 );
 banana2.getFallbackLocales(); // should return: [ 'ru', 'zh-hans' ]
 
 banana1.getMessage( 'message-key-2' ); // should return 'Localized message 2 for es with $1'


### PR DESCRIPTION
- `load()` is very flexible. It allows both `Messages` or `MessageSource` type objects as first param.
- Fix typo "messsageSource" -> "messageSource"
- In `BananaOptions`, messages is just passed to `load()` so this too can be `Messages | MessageSource`.
- Added `wikilinks` to `BananaOptions`, previously missing

