### PR TITLE
allow empty strings as messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ export default class Banana {
 
         const message = this.messageStore.getMessage(messageKey, tryingLocale)
 
-        if (message) {
+        if (typeof message === 'string') {
           return message
         }
 

--- a/test/banana.test.js
+++ b/test/banana.test.js
@@ -408,6 +408,17 @@ describe('Banana', function () {
     }, Error, 'Invalid message key.')
   })
 
+  it('should handle messages that are an empty string', () => {
+    const banana = new Banana('zh-hans', {
+      messages: {
+        'zh-hans': {
+          'word-separator': ''
+        }
+      }
+    })
+    assert.strictEqual(banana.i18n('word-separator'), '', 'Empty string message')
+  })
+
   it('should merge messages when added to an existing locale', () => {
     const banana = new Banana('ca', {
       messages: {


### PR DESCRIPTION
To be in line with MediaWiki allowing them. 

For example, in Chinese the word-separator is an empty string ([ref](https://github.com/wikimedia/mediawiki/blob/f6508708a6b97b66404d6de8979179c4a5f39475/languages/i18n/zh-hans.json#L3377)). So this is also useful in practise.