### PR TITLE
gender: when gender not passed, avoid error, fallback to neutral

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -213,14 +213,21 @@ export default function BananaMessage (message, { wikilinks = false } = {}) {
     return result === null ? null : [result[0], result[2]]
   }
 
+  function templateWithOutFirstParameter () {
+    const result = sequence([templateName, colon])
+    return result === null ? null : [result[0], '']
+  }
+
   const templateContents = choice([
     function () {
       const res = sequence([
         // templates can have placeholders for dynamic
         // replacement eg: {{PLURAL:$1|one car|$1 cars}}
-        // or no placeholders eg:
-        // {{GRAMMAR:genitive|{{SITENAME}}}
-        choice([templateWithReplacement, templateWithOutReplacement]),
+        // or no placeholders eg:{{GRAMMAR:genitive|{{SITENAME}}}
+        // Templates can also have empty first param eg:{{GENDER:|A|B|C}}
+        // to indicate current user in the context. We need to parse them without
+        // error, but can only fallback to gender neutral form.
+        choice([templateWithReplacement, templateWithOutReplacement, templateWithOutFirstParameter]),
         nOrMore(0, templateParam)
       ])
 

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -138,6 +138,10 @@ class BananaEmitter {
   /**
    * Transform parsed structure into gender Usage
    * {{gender:gender|masculine|feminine|neutral}}.
+   * The first node(gender) must be one of 'male', 'female' or 'unknown'
+   * Mediawiki allows this string as empty to indicate current logged in user.
+   * But this library cannot access such user contexts unless explclitly passed.
+   * So we need to fallback to gender neutral if it is empty.
    *
    * @param {Array} nodes List [ {String}, {String}, {String} , {String} ]
    * @return {string} selected gender form according to current language

--- a/test/banana.test.js
+++ b/test/banana.test.js
@@ -515,6 +515,13 @@ describe('Banana', function () {
       'This costs $1.',
       'No parameter supplied, $1 appears as is'
     )
+
+    const genderMessageWithoutExplicitGender = '{{gender:|He|She|They}}'
+    assert.strictEqual(
+      banana.i18n(genderMessageWithoutExplicitGender),
+      'They',
+      'Gender test - no gender passed'
+    )
   })
 
   it('should parse formatnum', () => {


### PR DESCRIPTION
Messages like {{GENDER:|A|B|C}} were causing parser failures.
This patch fixes the parser and introduce a fallback to neutral form.

As a mediawiki independent library, while Gender is supported, we cannot
support gender with current logged in user. For that explicit gender
param placeholder needed(example: {{GENDER:$1|A|B|C}}