### PR TITLE
Squashed commit of the following:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "banana-i18n",
-  "version": "2.3.3",
+  "version": "2.1.0",
   "description": "Banana Internationalization library",
   "main": "dist/banana-i18n.js",
   "scripts": {
     "test:types": "tsc -p ./types/tests/tsconfig.json",
     "test:unit": "mocha",
     "test": "npm run lint && npm run test:types && npm run test:unit",
-    "lint": "eslint src test scripts",
+    "lint": "eslint src test",
     "build": "rollup -c",
     "dev": "rollup -c -w"
   },
@@ -28,21 +28,21 @@
   "typings": "./types/index.d.ts",
   "license": "MIT",
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^13.1.3",
-    "axios": "^0.25.0",
-    "esbuild": "^0.14.12",
-    "eslint": "^7.32.0",
-    "eslint-config-standard": "^16.0.3",
-    "eslint-plugin-import": "^2.25.4",
+    "@rollup/plugin-node-resolve": "^11.2.1",
+    "esbuild": "^0.11.16",
+    "eslint": "^7.25.0",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.2.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^5.0.0",
     "esm": "^3.2.25",
-    "mocha": "^8.4.0",
-    "rollup": "^2.65.0",
-    "rollup-plugin-esbuild": "^4.8.2",
+    "mocha": "^8.3.2",
+    "rollup": "^2.46.0",
+    "rollup-plugin-esbuild": "^4.2.3",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.5.5"
+    "typescript": "^4.2.3"
   }
 }


### PR DESCRIPTION
commit eda37cb282552b0105eede1f5b30afb5bffa5d9d
Author: Santhosh Thottingal <santhosh.thottingal@gmail.com>
Date:   Fri May 14 14:26:11 2021 +0530

    build: Reduce the bundle size by using terser plugin with rollup

    With this, the current bundle size is about 20K, compared to 25K
    with esbuild minifier.

    Fixes issue #48