### PR TITLE
Deploy gh-pages for the demo pages

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,6 +34,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - run: npm install
+    - run: npm run build
     - name: Deploy Pages
       uses: JamesIves/github-pages-deploy-action@v4 
       with: 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,7 +38,8 @@ jobs:
       uses: actions/checkout@v4
     - run: npm install
     - run: npm run build
-    - name: Remove .gitignore
+    # Remove the .gitignore to ensure the dist folder is included for the demo page.
+    - name: Remove .gitignore 
       run: rm -f .gitignore
     - name: Deploy Pages
       uses: JamesIves/github-pages-deploy-action@v4 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,6 +38,8 @@ jobs:
       uses: actions/checkout@v4
     - run: npm install
     - run: npm run build
+    - name: Remove .gitignore
+      run: rm -f .gitignore
     - name: Deploy Pages
       uses: JamesIves/github-pages-deploy-action@v4 
       with: 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,3 +28,9 @@ jobs:
     - run: npm install
     - run: npm run build --if-present
     - run: npm test
+    
+    - name: Deploy Pages
+      uses: JamesIves/github-pages-deploy-action@v4 
+      with: 
+        folder: .
+        branch: gh-pages

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
@@ -28,7 +28,12 @@ jobs:
     - run: npm install
     - run: npm run build --if-present
     - run: npm test
+
+  build-and-deploy:
     
+    runs-on: ubuntu-latest
+
+    steps:
     - name: Deploy Pages
       uses: JamesIves/github-pages-deploy-action@v4 
       with: 


### PR DESCRIPTION
Phabricator: https://phabricator.wikimedia.org/T379709
Demo Page: https://wikimedia.github.io/banana-i18n/demo/

Add another build-and-deploy step to deploy pages to `gh-pages` branch

The `gh-pages` branch includes 
1. the original documentation page and 
1. the demo page list under `demo` folder

